### PR TITLE
Allow setting attributes in request tag

### DIFF
--- a/pysimplesoap/client.py
+++ b/pysimplesoap/client.py
@@ -195,6 +195,8 @@ class SoapClient(object):
             if parameters[0].children() is not None:
                 for param in parameters[0].children():
                     getattr(request, method).import_node(param)
+                for k,v in parameters[0].attributes().items():
+                    getattr(request, method)[k] = v
         elif parameters:
             # marshall parameters:
             use_ns = None if (self.__soap_server == "jetty" or self.qualified is False) else True


### PR DESCRIPTION
This is a fix for issue #89 in the google code repo. In client.py,
when constructing the request, it would omit any attributes in the
request tag. Been using this patch for a while now for interacting
with Zimbra's SOAP API, and it's been working beautifully.
