### PR TITLE
Include key in raised KeyError.  Also, failfast.

### DIFF
--- a/pysimplesoap/client.py
+++ b/pysimplesoap/client.py
@@ -347,10 +347,9 @@ class SoapClient(object):
             for idx, arg in enumerate(args):
                 key = list(inputargs.keys())[idx]
                 if isinstance(arg, dict):
-                    if key in arg:
-                        d[key] = arg[key]
-                    else:
-                        raise KeyError('Unhandled key %s. use client.help(method)')
+                    if key not in arg:
+                        raise KeyError('Unhandled key %s. use client.help(method)' % key)
+                    d[key] = arg[key]
                 else:
                     d[key] = arg
             all_args.update({inputname: d})


### PR DESCRIPTION
When the key is not found, a KeyError is raised without interpolating the specific key into the error message.  This fixes that.

Also, I reversed the logic to use a more failfast, or bail-out-early style.  I don't care if the style change sees the light of day, but I figured since I was changing the line anyway I might as well make it a little more readable, to my eye anyway.
