### PR TITLE
Do parse recursive `elements` in schema

### DIFF
--- a/pysimplesoap/client.py
+++ b/pysimplesoap/client.py
@@ -650,7 +650,7 @@ class SoapClient(object):
 
                 op = binding['operations'].setdefault(op_name, {})
                 op['name'] = op_name
-                op['style'] = op['style'] or style
+                op['style'] = op.get('style', style)
                 if action:
                     op['action'] = action
 

--- a/pysimplesoap/helpers.py
+++ b/pysimplesoap/helpers.py
@@ -180,8 +180,6 @@ def process_element(elements, element_name, node, element_type, xsd_uri,
                 ns, type_name = t
             else:
                 ns, type_name = None, t[0]
-            if element_name == type_name and not alias and len(children) > 1:
-                continue   # abort to prevent infinite recursion
             uri = ns and e.get_namespace_uri(ns) or xsd_uri
 
             # look for the conversion function (python type)


### PR DESCRIPTION
I didn't get why do you forbid recursive elements parsing in 68ef40e996e034f2f4bb23c0ca4454f10f4d9a60 and 9b07c32261050d897b55d83720fa863ada63f18e . There is no comment, ticket, bug report or testcase.

I've faced with bug — I have tree structure `HumanTaskTypeInfo` in my WSDL ( http://pastebin.com/pSn4P4mH ). Current version of `pysimplesoap` just drops `subtask` element from schema in parsing step and fails when receives this field from server on second.

I was really surprised then I've removed described lines — everything had been parsed well, no recursion, executed successfuly. Even unittests didn't report any bugs.

Pre- 68ef40e996e034f2f4bb23c0ca4454f10f4d9a60 version works good for me too.
# 

And small fix to my previous PR (about `style`).
