### PR TITLE
Fix posting non-ascii data via httplib[2]

### DIFF
--- a/pysimplesoap/client.py
+++ b/pysimplesoap/client.py
@@ -262,6 +262,7 @@ class SoapClient(object):
         """Send SOAP request using HTTP"""
         if self.location == 'test': return
         # location = '%s' % self.location #?op=%s" % (self.location, method)
+        http_method = str('POST')
         location = str(self.location)
 
         if self.services:
@@ -279,8 +280,15 @@ class SoapClient(object):
         log.debug('\n'.join(["%s: %s" % (k, v) for k, v in headers.items()]))
         log.debug(xml)
 
+        if sys.version < '3':
+            # Ensure http_method, location and all headers are binary to prevent
+            # UnicodeError inside httplib.HTTPConnection._send_output.
+
+            # httplib in python3 do the same inside itself, don't need to convert it here
+            headers = { str(k): str(v) for k, v in headers.items() }
+
         response, content = self.http.request(
-            location, 'POST', body=xml, headers=headers)
+            location, http_method, body=xml, headers=headers)
         self.response = response
         self.content = content
 


### PR DESCRIPTION
For python2:
Headers and http method had been unicode (because of `__future__  unicode_literals`), but location and body — string (bytes).
`httplib2` uses `httplib` inside, `httplib` tries to concatenate headers and strings, decoding payload bytes with default (ascii) encoder. `UnicodeError` happened.
I've converted all data to string, `httplib` sends it as is.

Python3:
`httplib` just works with unicode data everywhere. Everything is OK.

As usual unittests haven't become worse, but still didn't pass.
