### PR TITLE
Support `nil`s values

### DIFF
--- a/pysimplesoap/helpers.py
+++ b/pysimplesoap/helpers.py
@@ -91,12 +91,11 @@ def sort_dict(od, d):
         for k in od.keys():
             v = d.get(k)
             # don't append null tags!
-            if v is not None:
-                if isinstance(v, dict):
-                    v = sort_dict(od[k], v)
-                elif isinstance(v, list):
-                    v = [sort_dict(od[k][0], v1) for v1 in v]
-                ret[k] = v
+            if isinstance(v, dict):
+                v = sort_dict(od[k], v)
+            elif isinstance(v, list):
+                v = [sort_dict(od[k][0], v1) for v1 in v]
+            ret[k] = v
         if hasattr(od, 'namespaces'):
             ret.namespaces.update(od.namespaces)
             ret.references.update(od.references)

--- a/pysimplesoap/simplexml.py
+++ b/pysimplesoap/simplexml.py
@@ -502,7 +502,8 @@ class SimpleXMLElement(object):
         elif isinstance(value, (xml.dom.minidom.CDATASection, basestring)):  # do not convert strings or unicodes
             self.add_child(name, value, ns=ns)
         elif value is None:  # sent a empty tag?
-            self.add_child(name, ns=ns)
+            child = self.add_child(name, ns=ns)
+            child['xsi:nil'] = 'true'
         elif value in TYPE_MAP.keys():
             # add commented placeholders for simple tipes (for examples/help only)
             child = self.add_child(name, ns=ns)


### PR DESCRIPTION
Parse response `<item />` as empty string (`None` now), and `<item xsi:nil="true" />` as `None`.

Send `<item xsi:nil="true" />` nodes for `None` values in the request (it drops it out now).

As usual, tests haven't become worse.
