### PR TITLE
Feat/faultdetail

### DIFF
--- a/pysimplesoap/client.py
+++ b/pysimplesoap/client.py
@@ -27,7 +27,6 @@ import logging
 import os
 import tempfile
 import warnings
-import pprint
 
 from . import __author__, __copyright__, __license__, __version__, TIMEOUT
 from .simplexml import SimpleXMLElement, TYPE_MAP, REVERSE_TYPE_MAP, Struct

--- a/pysimplesoap/client.py
+++ b/pysimplesoap/client.py
@@ -27,6 +27,7 @@ import logging
 import os
 import tempfile
 import warnings
+import pprint
 
 from . import __author__, __copyright__, __license__, __version__, TIMEOUT
 from .simplexml import SimpleXMLElement, TYPE_MAP, REVERSE_TYPE_MAP, Struct
@@ -40,12 +41,12 @@ from .wsse import UsernameToken
 
 log = logging.getLogger(__name__)
 
-
 class SoapFault(RuntimeError):
-    def __init__(self, faultcode, faultstring):
+    def __init__(self, faultcode, faultstring, detail=None):
         self.faultcode = faultcode
         self.faultstring = faultstring
-        RuntimeError.__init__(self, faultcode, faultstring)
+        self.detail = detail
+        RuntimeError.__init__(self, faultcode, faultstring, detail)
 
     def __unicode__(self):
         return '%s: %s' % (self.faultcode, self.faultstring)
@@ -57,8 +58,9 @@ class SoapFault(RuntimeError):
             return self.__unicode__().encode('ascii', 'ignore')
 
     def __repr__(self):
-        return "SoapFault(%s, %s)" % (repr(self.faultcode),
-                                      repr(self.faultstring))
+        return "SoapFault(faultcode = %s, faultstring %s, detail = %s)" % (repr(self.faultcode),
+                                                                           repr(self.faultstring),
+                                                                           repr(self.detail))
 
 
 # soap protocol specification & namespace
@@ -260,7 +262,17 @@ class SoapClient(object):
         response = SimpleXMLElement(self.xml_response, namespace=self.namespace,
                                     jetty=self.__soap_server in ('jetty',))
         if self.exceptions and response("Fault", ns=list(soap_namespaces.values()), error=False):
-            raise SoapFault(unicode(response.faultcode), unicode(response.faultstring))
+            detailXml = response("detail", ns=list(soap_namespaces.values()), error=False)
+            detail = None
+
+            if detailXml and detailXml.children():
+                operation = self.get_operation(method)
+                fault = operation['faults'][detailXml.children()[0].get_name()]
+                detail = detailXml.children()[0].unmarshall(fault, strict=False)
+
+            raise SoapFault(unicode(response.faultcode),
+                            unicode(response.faultstring),
+                            detail)
 
         # do post-processing using plugins (i.e. WSSE signature verification)
         for plugin in self.plugins:
@@ -649,6 +661,11 @@ class SoapClient(object):
                 if operation_node('output', error=False):
                     op['output_msg'] = get_local_name(operation_node.output['message'])
 
+                #Get all fault message types this operation may return
+                fault_msgs = op['fault_msgs'] = {}
+                for fault in operation_node('fault', error=False):
+                    fault_msgs[fault['name']] = get_local_name(fault['message'])
+
         for binding_node in wsdl.binding:
             port_type_name = get_local_name(binding_node['type'])
             if port_type_name not in port_types:
@@ -733,6 +750,13 @@ class SoapClient(object):
                     del op['output_msg']
                 else:
                     op['output'] = None
+
+                if 'fault_msgs' in op:
+                    faults = op['faults'] = {}
+                    for name, msg in op['fault_msgs'].iteritems():
+                        msg_obj = get_message(messages, msg, parts_output_body)
+                        tag_name = msg_obj.keys()[0]
+                        faults[tag_name] = msg_obj
 
                 # useless? never used
                 parts_output_headers = []


### PR DESCRIPTION
I've added client side support for receiving and unmarshaling the detail element of a SOAP Fault, in accordance to the [SOAP 1.1 spec](http://www.w3.org/TR/2000/NOTE-SOAP-20000508/#_Toc478383507).  My implementation involved some design decisions that affect the API, so I thought it would be appropriate that others have a chance to review this before it gets merged.

I've tested this and verified it works with a .NET WCF service, that throws a custom FaultContract.

Sample Usage
If a client request to a service results in the following SOAP Fault:
```xml
<s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/" xmlns:u="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd">
  <s:Header>
    <!--Removed -->
  </s:Header>
  <s:Body>
    <s:Fault>
      <faultcode>s:Client</faultcode>
      <faultstring xml:lang="en-US">My service encountered an error.</faultstring>
      <detail>
        <MyApplicationFault xmlns="http://schemas.company.com/faults" xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
          <ErrorCode>Fatal error!</ErrorCode>
          <AffectedUsers xmlns:a="http://schemas.microsoft.com/2003/10/Serialization/Arrays">
            <a:string>Georges</a:string>
            <a:string>Johnny</a:string>
            <a:string>Robbie</a:string>
          </AffectedUsers>
        </MyApplicationFault>
      </detail>
    </s:Fault>
  </s:Body>
</s:Envelope>
```

```python
try:
  client = SoapClient(wsdl="https://company.com/testservice?singleWsdl")
  client.Insert(businessObject)
except SoapFault as e:
  print e
  if(e.detail):
    pprint.pprint(e.detail)

'''output:
s:Client: My service encountered an error.
{'MyApplicationFault': {'ErrorCode': u 'Fatal error!',
                        'AffectedUsers': [{'string': u 'Georges'},
                                          {'string': u 'Johnnie'},
                                          {'string': u 'Robbie'}]
                       }
}
'''
```

Comments:

1. According to the SOAP 1.1 spec, a SOAP Fault can actually have multiple Detail elements, and each one can contain multiple child elements.  I've only added support for a single detail element with a single child.  This matches WCF, which only supports for a single Detail element with a single child.  I'm pretty sure that Java Metro is also the same in this regard.
2. I did not modify \_\_unicode\_\_ or \_\_str\_\_, because in my experience details can be huge and would make the string unreadable.  I did change \_\_repr\_\_.
3. I noticed that the current SoapFault class only supports SOAP 1.1.  In 1.2, the names of the fault properties have changed (e.g. faultcode is now just code).