### PR TITLE
Remove, self=selv from lambda expression in method dispatch

### DIFF
--- a/pysimplesoap/client.py
+++ b/pysimplesoap/client.py
@@ -175,7 +175,7 @@ class SoapClient(object):
     def __getattr__(self, attr):
         """Return a pseudo-method that can be called"""
         if not self.services:  # not using WSDL?
-            return lambda self=self, *args, **kwargs: self.call(attr, *args, **kwargs)
+            return lambda *args, **kwargs: self.call(attr, *args, **kwargs)
         else:  # using WSDL:
             return lambda *args, **kwargs: self.wsdl_call(attr, *args, **kwargs)
 


### PR DESCRIPTION
Hallo pysimplesoap devs and thanks for a great lib.

We recently wanted to use pysimplesoap for [SoCo](https://github.com/SoCo/SoCo), but we ran into some problems using the method dispatch for "without WSDL" and with the elements listed as args. The problem we have, is that the service we want to connect with, is dependent on a specific order of the elements. This means that we cannot use the keyword form of the call spec. When reading through the code, one discovers that it should be possible to call it with the elements as (tag_name, value) args. But when doing that with the method dispatch one gets an exception `AttributeError: 'int' object has no attribute 'call'`. I did not save a traceback, but I can re-create the behavior with this test code:

``` python
class Foo(object):
    def __getattr__(self, attr):
        return lambda *args, **kwargs: self.call(attr, *args, **kwargs)

    def call(self, attr, *args, **kwargs):
        print "self", self
        print "attr", attr
        print "args", args
        print "kwargs", kwargs

class Bar(object):
    def __getattr__(self, attr):
        return lambda self=self, *args, **kwargs: self.call(attr, *args, **kwargs)

    def call(self, attr, *args, **kwargs):
        print "attr", attr
        print "args", args
        print "kwargs", kwargs

if __name__ == '__main__':
    foo = Foo()
    print "No self=self"
    print "\nargs only"
    foo.fancy_name(1, 2, 3)
    print "\nkwargs only"
    foo.fancy_name(c=4, d=5, e=6)
    print "\nmixed"
    foo.fancy_name(1, 2, 3, c=4, d=5, e=6)

    print "\n\nWith self=self"
    bar = Bar()
    print "\nargs only"
    bar.fancy_name(1, 2, 3)
    print "\nkwargs only"
    bar.fancy_name(c=4, d=5, e=6)
    print "\nmixed"
    bar.fancy_name(1, 2, 3, c=4, d=5, e=6)
```

If we use the call method directly with the method name as first arg, it works fine.

At a glance, and the way I understand the lambdas, that something=something syntax is used to lock a lambda call value to the value it had at lambda creation time, but I do not see why that should be necessary here (if it is even possible with mutable objects), or why it should be any different from the WSDL case two lines below.

It may of course just be that I missed something, so I look forward to your input.

If you require the actual traceback, I can re-create it for you.

Regards Kenneth
