### PR TITLE
fix python 3 breaking on .iteritems

### DIFF
--- a/pysimplesoap/client.py
+++ b/pysimplesoap/client.py
@@ -754,7 +754,7 @@ class SoapClient(object):
 
                 if 'fault_msgs' in op:
                     faults = op['faults'] = {}
-                    for name, msg in op['fault_msgs'].iteritems():
+                    for msg in op['fault_msgs'].values():
                         msg_obj = get_message(messages, msg, parts_output_body)
                         tag_name = msg_obj.keys()[0]
                         faults[tag_name] = msg_obj


### PR DESCRIPTION
The dict in Python 3 does not have the .iteritems method, so this should make it work in both Python 2 and 3 again.