### PR TITLE
Do not unmarshall fault detail if there was no WSDL

### DIFF
--- a/pysimplesoap/client.py
+++ b/pysimplesoap/client.py
@@ -272,7 +272,7 @@ class SoapClient(object):
                     detail = detailXml.children()[0].unmarshall(
                         fault, strict=False)
                 else:
-                    detail = detailXml.children()
+                    detail = repr(detailXml.children())
 
             raise SoapFault(unicode(response.faultcode),
                             unicode(response.faultstring),

--- a/pysimplesoap/client.py
+++ b/pysimplesoap/client.py
@@ -265,9 +265,14 @@ class SoapClient(object):
             detail = None
 
             if detailXml and detailXml.children():
-                operation = self.get_operation(method)
-                fault = operation['faults'][detailXml.children()[0].get_name()]
-                detail = detailXml.children()[0].unmarshall(fault, strict=False)
+                if self.services is not None:
+                    operation = self.get_operation(method)
+                    fault = operation['faults'][
+                        detailXml.children()[0].get_name()]
+                    detail = detailXml.children()[0].unmarshall(
+                        fault, strict=False)
+                else:
+                    detail = detailXml.children()
 
             raise SoapFault(unicode(response.faultcode),
                             unicode(response.faultstring),


### PR DESCRIPTION
Pull request #29 has introduced a bug where pysimplesoap is used without a WSDL file (i.e. with manual unmarshalling) and a SoapFault with detail is raised, because  `self.get_operation(method)` will fail.

This pull request fixes it. Where `pysimplesoap.client.services` is `None` (which is the case where no WSDL has been used) it sets SoapFault.detail to the raw xml returned by the server in the `<detail>` tag, so that it can be unmarshalled manually by the user.