### PR TITLE
remove print statement from setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,6 @@ if os.path.exists("README.md") and sys.platform == "linux2":
     try:
         cmd = ['pandoc', '--from=markdown', '--to=rst', 'README.md']
         long_desc = subprocess.check_output(cmd).decode("utf8")
-        print "Long DESC", long_desc
     except Exception as e:
         warnings.warn("Exception when converting the README format: %s" % e)
 


### PR DESCRIPTION
Since Python 3 support is broken until 81005a136 makes it into a release, I tried to install pysimplesoap from git by putting

```
-e git://github.com/pysimplesoap/pysimplesoap.git@fc9a9f394e2db8de136bb2627b6845712417dd92#egg=pysimplesoap
```

into my requirements.txt. This unfortunately also fails because setup.py contains a Python 2 print statement. This PR just removes that statement as it appears to be left in there accidentally and its generally not a good idea to have setup.py print stuff on import.

Please also consider a new release to fix Python 3 support. Thanks!