### PR TITLE
Support multiple occurrence of a XML node

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -40,3 +40,4 @@ Patches and Suggestions
 - jpc <jpc@alumni.rice.edu>
 - Luka Birsa
 - Bill Bennert @billwebreply
+- Sean E. Millichamp

--- a/pysimplesoap/simplexml.py
+++ b/pysimplesoap/simplexml.py
@@ -385,7 +385,9 @@ class SimpleXMLElement(object):
             if isinstance(fn, list):
                 # append to existing list (if any) - unnested dict arrays -
                 value = d.setdefault(name, [])
-                children = node.children()
+                # If the node has no children then the node itself might
+                # have multiple occurrences:
+                children = node.children() or node
                 # TODO: check if this was really needed (get first child only)
                 ##if len(fn[0]) == 1 and children:
                 ##    children = children()

--- a/tests/simplexmlelement_test.py
+++ b/tests/simplexmlelement_test.py
@@ -141,6 +141,29 @@ class TestSimpleXMLElement(unittest.TestCase):
             )}}
         self.eq(span.unmarshall(d), e)
 
+    def test_multiple_element_unmarshall_one(self):
+        xml = """
+        <results>
+            <foo>bar</foo>
+        </results>
+        """
+        span = SimpleXMLElement(xml)
+        d = {'results': {'foo': [str]}}
+        e = {'results': {'foo': ['bar']}}
+        self.eq(span.unmarshall(d), e)
+
+    def test_multiple_element_unmarshall_two(self):
+        xml = """
+        <results>
+            <foo>bar</foo>
+            <foo>baz</foo>
+        </results>
+        """
+        span = SimpleXMLElement(xml)
+        d = {'results': {'foo': [str]}}
+        e = {'results': {'foo': ['bar', 'baz']}}
+        self.eq(span.unmarshall(d), e)
+
     def test_basic(self):
         span = SimpleXMLElement(
             '<span><a href="python.org.ar">pyar</a>'


### PR DESCRIPTION
This patch adds support for a SOAP response where a multi-valued
response may be presented in multiple occurrences of the named
node.

I have included tests which ought to show the scenario this is intended to address.