### PR TITLE
Encode fault detail string as UTF-8

### DIFF
--- a/pysimplesoap/server.py
+++ b/pysimplesoap/server.py
@@ -207,8 +207,8 @@ class SoapDispatcher(object):
             etype, evalue, etb = sys.exc_info()
             log.error(traceback.format_exc())
             if self.debug:
-                detail = ''.join(traceback.format_exception(etype, evalue, etb))
-                detail += '\n\nXML REQUEST\n\n' + xml
+                detail = u''.join(traceback.format_exception(etype, evalue, etb))
+                detail += u'\n\nXML REQUEST\n\n' + xml.decode('UTF-8')
             else:
                 detail = None
             fault.update({'faultcode': "%s.%s" % (soap_fault_code, etype.__name__),


### PR DESCRIPTION
Previously any unicode points which were present in exception messages were causing a UnicodeDecodeError as they were being appended to an ascii string.

      File "/usr/local/lib/python2.7/dist-packages/pysimplesoap/server.py", line 211, in dispatch
        detail += '\n\nXML REQUEST\n\n' + xml
    UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 482: ordinal not in range(128)

You can simulate a request which causes this by deliberately providing invalid input (e.g. a unicode snowman where an integer is expected. With this patch the server returns a soap client validation error as expected, instead of a 500 internal server error:

     Client.ValueError: Tag: Blah: 'decimal' codec can't encode character u'\u2603' in position 0: invalid decimal Unicode string
