### PR TITLE
removed useless lambda self argument

### DIFF
--- a/pysimplesoap/client.py
+++ b/pysimplesoap/client.py
@@ -172,7 +172,7 @@ class SoapClient(object):
     def __getattr__(self, attr):
         """Return a pseudo-method that can be called"""
         if not self.services:  # not using WSDL?
-            return lambda self=self, *args, **kwargs: self.call(attr, *args, **kwargs)
+            return lambda *args, **kwargs: self.call(attr, *args, **kwargs)
         else:  # using WSDL:
             return lambda *args, **kwargs: self.wsdl_call(attr, *args, **kwargs)
 


### PR DESCRIPTION
The lambda needs not to be called with self as first argument, it can
access self from the closure, where self doesn't change.
This permits to use SoapClient methods in non-wsdl mode with non
keywords arguments. Otherwise first non-keyword arguments is absorbed by
lambda as self.
Fixes #31