### PR TITLE
marshalling list items

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Changelog
 ---------
 
 Recent changes (2014/2015):
-
+* added marshalling of list arguments (worked for axis server, xml compliant??)
 * Plug-in system to support for WSSE (Web-Services Security extensions)
 * WSSE UsernameToken, UsernameDigestToken and BinaryTokenSignature support
 * Pythonic XML Security Library basic implementation (canonicalization, SHA1 hashing and RSA signing / verification using X509 digital certificates)

--- a/pysimplesoap/client.py
+++ b/pysimplesoap/client.py
@@ -215,7 +215,11 @@ class SoapClient(object):
                     ns = v.namespaces.get(None, True)
                 else:
                     ns = use_ns
-                getattr(request, method).marshall(k, v, ns=ns)
+                    if isinstance(v, list):
+            	        for i in v:
+			                getattr(request, method).marshall(k, i, ns=ns)
+                    else:
+            	        getattr(request, method).marshall(k, v, ns=ns)
         elif self.__soap_server in ('jbossas6',):
             # JBossAS-6 requires no empty method parameters!
             delattr(request("Body", ns=list(soap_namespaces.values()),), method)


### PR DESCRIPTION
Hi all,

I had to modify the client.py because my axis server was reading only the first item of the list. Is this a standard XML behaviour or just my server or in general all axis servers? Without this change the list was marshalled as a single object. Please excuse my poor XML knowledge ;)

M