### PR TITLE
Attempt to use "xmlns", if prefix is missing.

### DIFF
--- a/pysimplesoap/client.py
+++ b/pysimplesoap/client.py
@@ -796,7 +796,7 @@ class SoapClient(object):
                 binding = ports[port['name']] = copy.deepcopy(bindings[binding_name])
                 address = port('address', ns=list(soap_uris.values()), error=False)
                 location = address and address['location'] or None
-                soap_uri = address and soap_uris.get(address.get_prefix())
+                soap_uri = address and soap_uris.get(address.get_prefix()) or address["xmlns"]
                 soap_ver = soap_uri and self.soap_ns_uris.get(soap_uri)
 
                 binding.update({


### PR DESCRIPTION
When the prefix is missing (i.e. the get_prefix() function returns None), both the "soap_uri" and the "soap_ver" variables are set to None, without testing whether a "xmlns" attibute (with a "prefix") is available.