### PR TITLE
Python 3 compatibility: Avoid TypeError with PycURL

### DIFF
--- a/pysimplesoap/transport.py
+++ b/pysimplesoap/transport.py
@@ -191,7 +191,7 @@ else:
                 c.setopt(c.CAINFO, self.cacert)
             c.setopt(pycurl.SSL_VERIFYPEER, self.cacert and 1 or 0)
             c.setopt(pycurl.SSL_VERIFYHOST, self.cacert and 2 or 0)
-            c.setopt(pycurl.CONNECTTIMEOUT, self.timeout / 6)
+            c.setopt(pycurl.CONNECTTIMEOUT, self.timeout)
             c.setopt(pycurl.TIMEOUT, self.timeout)
             if method == 'POST':
                 c.setopt(pycurl.POST, 1)


### PR DESCRIPTION
In Python 3: int / int = float

Integer timeout divided by a constant becomes a float in Python 3 (see
PEP 238), which results in a TypeError when passing it as argument to
PycURL's setopt().