### PR TITLE
Drop transitional package (fixes #63 and #101)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,30 +24,27 @@ if os.path.exists("README.md") and sys.platform == "linux2":
     except Exception as e:
         warnings.warn("Exception when converting the README format: %s" % e)
 
-
-# in the transition, register both:
-for name in ('soap2py', 'PySimpleSOAP'):
-    setup(
-        name=name,
-        version=__version__,
-        description='Python simple and lightweight SOAP Library',
-        long_description=long_desc,
-        author=__author__,
-        author_email=__author_email__,
-        url='http://code.google.com/p/pysimplesoap',
-        packages=['pysimplesoap'],
-        license=__license__,
-    #    console=['client.py'],
-        cmdclass={"py2exe": build_installer},
-        classifiers=[
-            "Development Status :: 3 - Alpha",
-            "License :: OSI Approved :: GNU Lesser General Public License v3 or later (LGPLv3+)",
-            "Operating System :: OS Independent",
-            "Programming Language :: Python :: 2",
-            "Programming Language :: Python :: 2.7",
-            "Programming Language :: Python :: 3",
-            "Topic :: Internet :: WWW/HTTP :: WSGI :: Application",
-            "Topic :: Communications",
-            "Topic :: Software Development :: Libraries :: Python Modules",
-        ],
-    )
+setup(
+    name='PySimpleSOAP',
+    version=__version__,
+    description='Python simple and lightweight SOAP Library',
+    long_description=long_desc,
+    author=__author__,
+    author_email=__author_email__,
+    url='http://code.google.com/p/pysimplesoap',
+    packages=['pysimplesoap'],
+    license=__license__,
+    # console=['client.py'],
+    cmdclass={"py2exe": build_installer},
+    classifiers=[
+        "Development Status :: 3 - Alpha",
+        "License :: OSI Approved :: GNU Lesser General Public License v3 or later (LGPLv3+)",
+        "Operating System :: OS Independent",
+        "Programming Language :: Python :: 2",
+        "Programming Language :: Python :: 2.7",
+        "Programming Language :: Python :: 3",
+        "Topic :: Internet :: WWW/HTTP :: WSGI :: Application",
+        "Topic :: Communications",
+        "Topic :: Software Development :: Libraries :: Python Modules",
+    ],
+)


### PR DESCRIPTION
New versions of setuptools/pip build wheels by default and cache them.
Calling setup() twice breaks wheels.
Therefore pysimplesoap is getting increasingly difficult to install for increasing numbers of users.
This behaviour was to meant to help users, and is now harming them, so should be removed.