### PR TITLE
Fix pycurl transport for python3.

### DIFF
--- a/pysimplesoap/transport.py
+++ b/pysimplesoap/transport.py
@@ -170,7 +170,7 @@ else:
         try:
             from StringIO import StringIO
         except ImportError:
-            from io import StringIO
+            from io import BytesIO as StringIO
 
     class pycurlTransport(TransportBase):
         _wrapper_version = pycurl.version


### PR DESCRIPTION
Related to #107

According to the [pycurl documentation](http://pycurl.io/docs/latest/unicode.html#writing-to-stringio-bytesio) in python > 3 pycurl needs a BytesIO instance instead of StringIO
to write the response.