### PR TITLE
Remove unicode literals (fixes pre-3.3 python3)

### DIFF
--- a/pysimplesoap/server.py
+++ b/pysimplesoap/server.py
@@ -207,8 +207,8 @@ class SoapDispatcher(object):
             etype, evalue, etb = sys.exc_info()
             log.error(traceback.format_exc())
             if self.debug:
-                detail = u''.join(traceback.format_exception(etype, evalue, etb))
-                detail += u'\n\nXML REQUEST\n\n' + xml.decode('UTF-8')
+                detail = ''.join(traceback.format_exception(etype, evalue, etb))
+                detail += '\n\nXML REQUEST\n\n' + xml.decode('UTF-8')
             else:
                 detail = None
             fault.update({'faultcode': "%s.%s" % (soap_fault_code, etype.__name__),


### PR DESCRIPTION
Removed two unicode literals from server.py.

Unicode literals returned to Python in 3.3 for exclusively for backwards compatibility, but ironically cause backward compatibility within Python 3. Seeing how pysimplesoap is already using unicode_literals from __future__ anyhow, it seemed worth nuking them to fix 3.0-3.2 compatibility.