### PR TITLE
Add quotes to SOAPAction header in SoapClient

### DIFF
--- a/pysimplesoap/client.py
+++ b/pysimplesoap/client.py
@@ -300,7 +300,7 @@ class SoapClient(object):
         }
 
         if self.action is not None:
-            headers['SOAPAction'] = soap_action
+            headers['SOAPAction'] = '"' + soap_action + '"'
 
         headers.update(self.http_headers)
         log.info("POST %s" % location)


### PR DESCRIPTION
According to the SOAP standard, the `SOAPAction` HTTP field must be
quoted by double quotes unless the URI is empty and 'there is no
indication of the intent of the message' [1].

Not having proper quoting leads to gupnp based devices reply with invalid
XML. While there is a proposed fix for that to handle unquoted requests more
gracefully [2], the real issue in SoapClient implementation.

[1] https://www.w3.org/TR/2000/NOTE-SOAP-20000508/#_Toc478383528
[2] https://bugzilla.gnome.org/show_bug.cgi?id=793955