### PR TITLE
fix: TypeError: unhashable type: 'dict'

### DIFF
--- a/pysimplesoap/server.py
+++ b/pysimplesoap/server.py
@@ -369,11 +369,7 @@ class SoapDispatcher(object):
                     e['name'] = k
                     if array:
                         e[:] = {'minOccurs': "0", 'maxOccurs': "unbounded"}
-                    if v in TYPE_MAP.keys():
-                        t = 'xsd:%s' % TYPE_MAP[v]
-                    elif v is None:
-                        t = 'xsd:anyType'
-                    elif isinstance(v, list):
+                    if isinstance(v, list):
                         n = "ArrayOf%s%s" % (name, k)
                         l = []
                         for d in v:
@@ -384,6 +380,10 @@ class SoapDispatcher(object):
                         n = "%s%s" % (name, k)
                         parse_element(n, v.items(), complex=True)
                         t = "tns:%s" % n
+                    elif v is None:
+                        t = 'xsd:anyType'
+                    elif v in TYPE_MAP.keys():
+                        t = 'xsd:%s' % TYPE_MAP[v]
                     else:
                         raise TypeError("unknonw type %s for marshalling" % str(v))
                     e.add_attribute('type', t)


### PR DESCRIPTION
Line that error occurred: 372
Source code that error occurred: 
```python
if v in TYPE_MAP.keys():
```
## Description:
If the type of "v" is "dict" or "list", it will raise an exception like below.

Traceback (most recent call last):
  File "/usr/local/lib/python3.5/dist-packages/lambda_local/main.py", line 92, in execute
    result = func(event, context.activate())
  File "app.py", line 141, in handler
    wsdl = dispatcher.wsdl()
  File "/rempus/soap_transition/pysimplesoap/server.py", line 391, in wsdl
    parse_element("%s" % method, args and args.items())
  File "/rempus/soap_transition/pysimplesoap/server.py", line 372, in parse_element
    if v in TYPE_MAP.keys():
TypeError: unhashable type: 'dict'

So, I've changed the order of if, elif lines and logic belong them. Let it check by isinstance method first, then check if it is None, and finally the rest checking logic go through.