### PR TITLE
Use super() to call parent methods (Fixes #171)

### DIFF
--- a/pysimplesoap/simplexml.py
+++ b/pysimplesoap/simplexml.py
@@ -124,20 +124,21 @@ from collections import OrderedDict as ordered_dict
 class OrderedDict(ordered_dict):
     "Minimal ordered dictionary for xsd:sequences"
     def __init__(self):
+        super().__init__()
         self.__keys = []
         self.array = False
     def __setitem__(self, key, value):
         if key not in self.__keys:
             self.__keys.append(key)
-        ordered_dict.__setitem__(self, key, value)
+        super().__setitem__(key, value)
     def insert(self, key, value, index=0):
         if key not in self.__keys:
             self.__keys.insert(index, key)
-        ordered_dict.__setitem__(self, key, value)
+        super().__setitem__(key, value)
     def __delitem__(self, key):
         if key in self.__keys:
             self.__keys.remove(key)
-        ordered_dict.__delitem__(self, key)
+        super().__delitem__(key)
     def __iter__(self):
         return iter(self.__keys)
     def keys(self):
@@ -156,7 +157,7 @@ class OrderedDict(ordered_dict):
         new.update(self)
         return new
     def __str__(self):
-        return "*%s*" % ordered_dict.__str__(self)
+        return "*%s*" % super().__str__()
     def __repr__(self):
         s= "*{%s}*" % ", ".join(['%s: %s' % (repr(k),repr(v)) for k,v in list(self.items())])
         if self.array and False:


### PR DESCRIPTION
While using ```ClassName.method(self,...)``` is legal, it's better to use ```super().method(...)```

Also, call ```super().__init__()``` to correctly initialize the OrderedDict attributes.