### PR TITLE
[FIX] pysimplesoap: fix how the children process the namespace

### DIFF
--- a/pysimplesoap/client.py
+++ b/pysimplesoap/client.py
@@ -79,7 +79,7 @@ class SoapClient(object):
                  sessions=False, soap_server=None, timeout=TIMEOUT,
                  http_headers=None, trace=False,
                  username=None, password=None,
-                 key_file=None, plugins=None, strict=True,
+                 key_file=None, plugins=None, strict=True, no_ns_children=False,
                  ):
         """
         :param http_headers: Additional HTTP Headers; example: {'Host': 'ipsec.example.com'}
@@ -94,6 +94,7 @@ class SoapClient(object):
         self.http_headers = http_headers or {}
         self.plugins = plugins or []
         self.strict = strict
+        self.no_ns_children = no_ns_children
         # extract the base directory / url for wsdl relative imports:
         if wsdl and wsdl_basedir == '':
             # parse the wsdl url, strip the scheme and filename
@@ -209,7 +210,8 @@ class SoapClient(object):
             body.import_node(parameters[0])
         elif parameters:
             # marshall parameters:
-            use_ns = None if (self.__soap_server == "jetty" or self.qualified is False) else True
+            use_ns = None if (self.no_ns_children or self.__soap_server == "jetty" or self.qualified is False) else True
+
             for k, v in parameters:  # dict: tag=valor
                 if hasattr(v, "namespaces") and use_ns:
                     ns = v.namespaces.get(None, True)


### PR DESCRIPTION
Currently, I'm moving to another service where they have the rule that: There should not be any atribute in the childs of the service you are consuming. But the new label should have the attribute.

Then, we have the bad_xml I'm generating with pysimplesoap
```xml
<?xml version="1.0" encoding="UTF-8"?>
<soapenv:Envelope xmlns:ser="http://service.sunat.gob.pe" xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/">
<soapenv:Header>
    <wsse:Security xmlns:wsse="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd">
    <wsse:UsernameToken>
        <wsse:Username>username</wsse:Username>
        <wsse:Password>password</wsse:Password>
    </wsse:UsernameToken>
</wsse:Security>
</soapenv:Header>
<soapenv:Body>
    <ser:sendBill>
        <ser:fileName>Random_encripted_filename.zip</ser:fileName>
        <ser:contentFile>Random_encripted_file.zip</ser:contentFile>
    </ser:sendBill>
</soapenv:Body>
</soapenv:Envelope>
``` 
When you create a SoapClient, you can't anywhere(as far as I know) if you want the childs to have a namespace, because everything falls under the method **call** that will usually generate the request and send it. Meaning, that we will always have a namespace we like it or not.

With this change, we can decide with another argument in the creation of the client.

The idea of this PR is to create documents like this one below
```xml
<?xml version="1.0" encoding="UTF-8"?>
<soapenv:Envelope xmlns:ser="http://service.sunat.gob.pe" xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/">
<soapenv:Header>
    <wsse:Security xmlns:wsse="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd">
    <wsse:UsernameToken>
        <wsse:Username>username</wsse:Username>
        <wsse:Password>password</wsse:Password>
    </wsse:UsernameToken>
</wsse:Security>
</soapenv:Header>
<soapenv:Body>
    <ser:sendBill>
        <fileName>Random_encripted_filename.zip</fileName>
        <contentFile>Random_encripted_file.zip</contentFile>
    </ser:sendBill>
</soapenv:Body>
</soapenv:Envelope>
```

