### PR TITLE
fixes #171 OrderedDict broken on Python 3.4

### DIFF
--- a/pysimplesoap/simplexml.py
+++ b/pysimplesoap/simplexml.py
@@ -124,6 +124,7 @@ from collections import OrderedDict as ordered_dict
 class OrderedDict(ordered_dict):
     "Minimal ordered dictionary for xsd:sequences"
     def __init__(self):
+        super(OrderedDict, self).__init__()
         self.__keys = []
         self.array = False
     def __setitem__(self, key, value):


### PR DESCRIPTION
The .__map[] dictionary was not correctly initilized because simplexml/OrderedDict didn't call parent's init().