### PR TITLE
Include license.txt, README.md, samples directory, and tests in pypi tarball

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,4 @@
+include README.md
+include license.txt
+recursive-include samples *.py
+recursive-include tests *


### PR DESCRIPTION
In OpenBSD we use the regression tests in order to make sure that updates
work properly and that an update of a dependency doesn't break a package.
Having the regression tests in the PyPI tarball makes that much easier.

While here, include the license.txt, README.md, and samples directory.