### PR TITLE
Patch for usage of WSDL "cache" feature for Python 3.4+

### DIFF
--- a/pysimplesoap/client.py
+++ b/pysimplesoap/client.py
@@ -876,8 +876,7 @@ class SoapClient(object):
                 'documentation': self.documentation,
                 'services': services,
             }
-            mode = 'wb' if py3 else 'w'
-            with open(filename_pkl, mode) as f:
+            with open(filename_pkl, 'wb') as f:
                 pickle.dump(pkl, f, protocol=pickle.HIGHEST_PROTOCOL)
 
         return services

--- a/pysimplesoap/helpers.py
+++ b/pysimplesoap/helpers.py
@@ -611,6 +611,7 @@ class Struct(dict):
     def __init__(self, key=None):
         super(dict, self).__init__()
         self.key = key
+        self.__keys = []
         self.array = False
         self.namespaces = {}     # key: element, value: namespace URI
         self.references = {}     # key: element, value: reference name

--- a/pysimplesoap/helpers.py
+++ b/pysimplesoap/helpers.py
@@ -15,7 +15,10 @@
 
 from __future__ import unicode_literals
 import sys
+
+py3 = False
 if sys.version > '3':
+    py3 = True
     basestring = unicode = str
 
 import datetime
@@ -63,9 +66,10 @@ def fetch(url, http, cache=False, force_download=False, wsdl_basedir='', headers
         filename = os.path.join(cache, filename)
     if cache and os.path.exists(filename) and not force_download:
         log.info('Reading file %s' % filename)
-        f = open(filename, 'r')
-        xml = f.read()
-        f.close()
+        mode = 'rt' if py3 else 'r'
+        with open(filename, mode) as f:
+            xml = f.read()
+            f.close()
     else:
         if url_scheme == 'file':
             log.info('Fetching url %s using urllib2' % url)
@@ -78,7 +82,8 @@ def fetch(url, http, cache=False, force_download=False, wsdl_basedir='', headers
             log.info('Writing file %s' % filename)
             if not os.path.isdir(cache):
                 os.makedirs(cache)
-            f = open(filename, 'w')
+            mode = 'wb' if py3 else 'w'
+            f = open(filename, mode)
             f.write(xml)
             f.close()
     return xml
@@ -601,7 +606,8 @@ if str not in TYPE_MAP:
 
 class Struct(dict):
     """Minimal ordered dictionary to represent elements (i.e. xsd:sequences)"""
-
+    __keys = []
+    
     def __init__(self, key=None):
         self.key = key
         self.__keys = []

--- a/pysimplesoap/helpers.py
+++ b/pysimplesoap/helpers.py
@@ -609,8 +609,8 @@ class Struct(dict):
     __keys = []
     
     def __init__(self, key=None):
+        super(dict, self).__init__()
         self.key = key
-        self.__keys = []
         self.array = False
         self.namespaces = {}     # key: element, value: namespace URI
         self.references = {}     # key: element, value: reference name


### PR DESCRIPTION
These changes fix a range of issues I was having when using the `SoapClient` initialized with `cache` set to a folder.

```
client = SoapClient(
    wsdl=config['some_wsdl'],
    location=config['some_location'],
    exceptions=True,
    cache='/some/cache/folder'
)
```
It seems that the issues were mainly due to incompatibilities with Python 3. Any suggestions for improvements on this code will be greatly appreciated. Please let me know if there is anything I am missing, and if so, I will update or close this request.

Thanks for the great work on this library.