### PR TITLE
Fix for error due to dictionary key type change from 'list' to 'dict_keys' in python3

### DIFF
--- a/pysimplesoap/server.py
+++ b/pysimplesoap/server.py
@@ -369,10 +369,10 @@ class SoapDispatcher(object):
                     e['name'] = k
                     if array:
                         e[:] = {'minOccurs': "0", 'maxOccurs': "unbounded"}
-                    if v in TYPE_MAP.keys():
-                        t = 'xsd:%s' % TYPE_MAP[v]
-                    elif v is None:
-                        t = 'xsd:anyType'
+                    if isinstance(v, dict):
+                        n = "%s%s" % (name, k)
+                        parse_element(n, v.items(), complex=True)
+                        t = "tns:%s" % n
                     elif isinstance(v, list):
                         n = "ArrayOf%s%s" % (name, k)
                         l = []
@@ -380,10 +380,10 @@ class SoapDispatcher(object):
                             l.extend(d.items())
                         parse_element(n, l, array=True, complex=True)
                         t = "tns:%s" % n
-                    elif isinstance(v, dict):
-                        n = "%s%s" % (name, k)
-                        parse_element(n, v.items(), complex=True)
-                        t = "tns:%s" % n
+                    elif v in TYPE_MAP.keys():
+                        t = 'xsd:%s' % TYPE_MAP[v]
+                    elif v is None:
+                        t = 'xsd:anyType'
                     else:
                         raise TypeError("unknonw type %s for marshalling" % str(v))
                     e.add_attribute('type', t)

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-from distutils.core import setup
+from setuptools import setup
 import os
 import subprocess
 import sys


### PR DESCRIPTION
Error occurred while checking whether a dictionary is present in the keys of of another dictionary:

> File "/usr/local/lib/python3.6/site-packages/pysimplesoap/server.py", line 521, in do_get
     response = self.dispatcher.wsdl()
   File "/usr/local/lib/python3.6/site-packages/pysimplesoap/server.py", line 395, in wsdl
     parse_element("%sResponse" % method, returns and returns.items())
   File "/usr/local/lib/python3.6/site-packages/pysimplesoap/server.py", line 375, in parse_element
     if v in TYPE_MAP.keys():
 TypeError: unhashable type: 'dict'