### PR TITLE
Remove inspect for Python 3.11 compatibility

### DIFF
--- a/pysimplesoap/client.py
+++ b/pysimplesoap/client.py
@@ -15,7 +15,7 @@
 __author__ = "Mariano Reingart (reingart@gmail.com)"
 __copyright__ = "Copyright (C) 2008 Mariano Reingart"
 __license__ = "LGPL 3.0"
-__version__ = "1.08.14"
+__version__ = "1.08.22"
 
 TIMEOUT = 60
 

--- a/pysimplesoap/transport.py
+++ b/pysimplesoap/transport.py
@@ -136,10 +136,7 @@ else:
     _http_connectors['httplib2'] = Httplib2Transport
     _http_facilities.setdefault('proxy', []).append('httplib2')
     _http_facilities.setdefault('cacert', []).append('httplib2')
-
-    import inspect
-    if 'timeout' in inspect.getargspec(httplib2.Http.__init__)[0]:
-        _http_facilities.setdefault('timeout', []).append('httplib2')
+    _http_facilities.setdefault('timeout', []).append('httplib2')
 
 #
 # urllib2 support.


### PR DESCRIPTION
Fixes issue in pyafipws:
```
/opt/hostedtoolcache/Python/3.11.0/x64/lib/python3.11/site-packages/pysimplesoap/transport.py:[14](https://github.com/reingart/pyafipws/actions/runs/3519199212/jobs/5898894972#step:13:15)1: in <module>
    if 'timeout' in inspect.getargspec(httplib2.Http.__init__)[0]:
E   AttributeError: module 'inspect' has no attribute 'getargspec'
```