### PR TITLE
Avoid inspect.getargspec

### DIFF
--- a/pysimplesoap/transport.py
+++ b/pysimplesoap/transport.py
@@ -106,7 +106,7 @@ else:
     _http_facilities.setdefault('cacert', []).append('httplib2')
 
     import inspect
-    if 'timeout' in inspect.getargspec(httplib2.Http.__init__)[0]:
+    if 'timeout' in inspect.getfullargspec(httplib2.Http.__init__).args:
         _http_facilities.setdefault('timeout', []).append('httplib2')
 
 


### PR DESCRIPTION
Avoid inspect.getargspec

This function is removed in Python 3.11 and has been deprecated for a
while. Use inspect.getfullargspec instead, which is also backwards
compatible with Python 2.
  
Fixes #159
